### PR TITLE
Mark the paragraph on the Contact page as Latin

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -4,6 +4,7 @@ menus: "main"
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+{lang="la"}
 
 Nee geintje, hier kun je me vinden:
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,4 +7,11 @@ theme = 'hugo-theme-zen'
 [Params]
   mobilemenu = true
   menuInHeader = true
- sectionPagesMenu = 'main'
+  sectionPagesMenu = 'main'
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.parser]
+      [markup.goldmark.parser.attribute]
+        block = true
+        title = true


### PR DESCRIPTION
- **Configure Hugo to allow Markdown attributes on block level elements (such as paragraphs)**
- **Set lang=la on the paragraph with Latin text on the contact page**
